### PR TITLE
Update azuredeploy_ttgw_ss.json

### DIFF
--- a/azuredeploy_ttgw_ss.json
+++ b/azuredeploy_ttgw_ss.json
@@ -194,10 +194,12 @@
     "avSetSvcFab": "avSetSvcFab",
     "avSetMgmnt": "avSetMgmnt",
     "applicationGatewayName": "appwgtosvcfab",
+     "appGatewayBackendPoolName": "appGatewayBackendPool",
     "publicGWIPAddressName": "appgwsvcfab",
 
     "publicGwIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicGWIPAddressName'))]",
     "applicationGatewayRef": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
+    "lbGatewayPoolID": "[concat(variables('applicationGatewayRef'),'/backendAddressPools/', variables('appGatewayBackendPoolName'))]",
     "apiVersion": "2015-05-01-preview",
 
     "vmImagePublisher": "MicrosoftWindowsServer",
@@ -587,6 +589,8 @@
                           "id": "[variables('svcFabSubnetRef')]"
                         },
                         "privateIPAllocationMethod": "Dynamic",
+                        "applicationGatewayBackendAddressPools":  [
+                          { "id": "[variables('lbGatewayPoolID')]",
                         "loadBalancerBackendAddressPools": [
                           { "id": "[variables('lbPoolID')]" }
                         ]
@@ -856,20 +860,7 @@
         ],
         "backendAddressPools": [
           {
-            "name": "appGwBackendPool",
-            "properties": {
-              "BackendAddresses": [
-                {
-                  "IpAddress": "10.0.2.4"
-                },
-                {
-                  "IpAddress": "10.0.2.5"
-                },
-                {
-                  "IpAddress": "10.0.2.6"
-                }
-              ]
-            }
+             "name": "[variables('appGatewayBackendPoolName')]"
           }
         ],
         "backendHttpSettingsCollection": [


### PR DESCRIPTION
Enable scaling for the nodeset and application gateway. This way if you add more nodes to your cluster you don't manually need to setup the new IP's to the Application Gateway.

Didn't test this script, just copied paste from mine, so hope it's working. If not, let me know, can help.